### PR TITLE
Update RewriteIvcOutputStream.java

### DIFF
--- a/com.creditease.uav.monitorframework.apm/src/main/java/com/creditease/uav/apm/RewriteIvcOutputStream.java
+++ b/com.creditease.uav.monitorframework.apm/src/main/java/com/creditease/uav/apm/RewriteIvcOutputStream.java
@@ -54,7 +54,7 @@ public class RewriteIvcOutputStream extends ServletOutputStream {
 
         this.outputStream.write(b, off, len);
         if (!isWrited) {
-            int remainderLength = getRemainderLength(b.length);
+            int remainderLength = getRemainderLength(len);
             if (remainderLength > 0) {
                 builder.append(new String(b, off, remainderLength, encoding));
             }


### PR DESCRIPTION
判断remainderLength时，应该用实际需要的长度而不是buf的长度